### PR TITLE
pass server port to socket.getaddrinfo instead of the string 'domain'

### DIFF
--- a/netbox_ddns/__init__.py
+++ b/netbox_ddns/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '1.2.7'
+VERSION = '1.2.8'
 
 try:
     from extras.plugins import PluginConfig

--- a/netbox_ddns/models.py
+++ b/netbox_ddns/models.py
@@ -113,7 +113,7 @@ class Server(models.Model):
 
     @property
     def address(self) -> Optional[str]:
-        addrinfo = socket.getaddrinfo(self.server, 'domain', proto=socket.IPPROTO_UDP)
+        addrinfo = socket.getaddrinfo(self.server, self.server_port, proto=socket.IPPROTO_UDP)
         for family, _, _, _, sockaddr in addrinfo:
             if family in (socket.AF_INET, socket.AF_INET6) and sockaddr[0]:
                 return sockaddr[0]


### PR DESCRIPTION
In the current `models.py` the string 'domain' is passed to `socket.getaddrinfo` while `getaddrinfo` expects the port number of the DNS server.
This string seems to be present since the initial commit, and I'm not sure why this was done initially, but currently this produces the `socket.gaierror: [Errno -8] Servname not supported for ai_socktype` error as described in #33.

Please let me know if this is an appropriate fix and if anyone knows why 'domain' was passed initially I'm all ears 🙂