### PR TITLE
version bump to allow installs on v3.6

### DIFF
--- a/netbox_ddns/__init__.py
+++ b/netbox_ddns/__init__.py
@@ -13,7 +13,7 @@ class NetBoxDDNSConfig(PluginConfig):
     verbose_name = 'Dynamic DNS'
     version = VERSION
     min_version = '3.0.0'
-    max_version = '3.5.999'
+    max_version = '3.6.999'
     author = 'Sander Steffann'
     author_email = 'sander@steffann.nl'
     description = 'Dynamic DNS Connector for NetBox'


### PR DESCRIPTION
updates max_version to support v3.6 of netbox - seems to work with no other changes necessary (nothing in changelog in v3.6+ to imply a breaking change to the plugin either)