### PR TITLE
fix: remove the netbox max version

### DIFF
--- a/netbox_ddns/__init__.py
+++ b/netbox_ddns/__init__.py
@@ -13,7 +13,6 @@ class NetBoxDDNSConfig(PluginConfig):
     verbose_name = 'Dynamic DNS'
     version = VERSION
     min_version = '3.0.0'
-    max_version = '3.6.999'
     author = 'Sander Steffann'
     author_email = 'sander@steffann.nl'
     description = 'Dynamic DNS Connector for NetBox'


### PR DESCRIPTION
Always an issue on major Netbox upgrades. 
Setting a minimum version makes sense to mark a minimal compatibility. 

ref: #41