### PR TITLE
Removing btn-sm class from buttons for compatibility with Netbox 4.0

### DIFF
--- a/netbox_ddns/__init__.py
+++ b/netbox_ddns/__init__.py
@@ -13,7 +13,7 @@ class NetBoxDDNSConfig(PluginConfig):
     verbose_name = 'Dynamic DNS'
     version = VERSION
     min_version = '4.0.0'
-    max_version = '4.0.999'
+    max_version = '4.1.999'
     author = 'Sander Steffann'
     author_email = 'sander@steffann.nl'
     description = 'Dynamic DNS Connector for NetBox'

--- a/netbox_ddns/tables.py
+++ b/netbox_ddns/tables.py
@@ -21,13 +21,13 @@ FORWARD_DNS = """
 ACTIONS = """
     {% if perms.netbox_ddns.change_extradnsname %}
         <a href="{% url 'plugins:netbox_ddns:extradnsname_edit' ipaddress_pk=record.ip_address.pk pk=record.pk %}" 
-           class="btn btn-sm btn-warning">
+           class="btn btn-warning">
             <i class="mdi mdi-pencil" aria-hidden="true"></i>
         </a>
     {% endif %}
     {% if perms.netbox_ddns.delete_extradnsname %}
         <a href="{% url 'plugins:netbox_ddns:extradnsname_delete' ipaddress_pk=record.ip_address.pk pk=record.pk %}"
-           class="btn btn-sm btn-danger">
+           class="btn btn-danger">
             <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i>
         </a>
     {% endif %}

--- a/netbox_ddns/templates/netbox_ddns/ipaddress/dns_extra.html
+++ b/netbox_ddns/templates/netbox_ddns/ipaddress/dns_extra.html
@@ -11,7 +11,7 @@
         {% if perms.netbox_ddns.add_extradnsname %}
             <div class="card-footer text-right noprint">
                 <a href="{% url 'plugins:netbox_ddns:extradnsname_create' ipaddress_pk=object.pk %}"
-                   class="btn btn-sm btn-primary">
+                   class="btn btn-primary">
                     <span class="mdi mdi-plus" aria-hidden="true"></span>Add extra DNS name
                 </a>
             </div>

--- a/netbox_ddns/templates/netbox_ddns/ipaddress/dns_refresh_button.html
+++ b/netbox_ddns/templates/netbox_ddns/ipaddress/dns_refresh_button.html
@@ -4,7 +4,7 @@
 
         <button type="submit" name="_edit"
                 formaction="{% url 'plugins:netbox_ddns:ipaddress_dnsname_recreate' ipaddress_pk=object.pk %}"
-                class="btn btn-sm btn-secondary">
+                class="btn btn-secondary">
             <span class="mdi mdi-refresh" aria-hidden="true"></span> Recreate DNS
         </button>
     </form>


### PR DESCRIPTION
According to the Netbox 4.0 plugin migration [instructions](https://netboxlabs.com/docs/netbox/en/stable/plugins/development/migration-v4/), we should remove the btn-sm class from all buttons.
