### PR TITLE
Bug fix: Moves protocol field to server serializer

### DIFF
--- a/netbox_ddns/api/serializers.py
+++ b/netbox_ddns/api/serializers.py
@@ -20,13 +20,20 @@ class ExtraDNSNameSerializer(NetBoxModelSerializer):
 class ServerSerializer(NetBoxModelSerializer):
     class Meta:
         model = Server
-        fields = ('server', 'server_port', 'tsig_key_name', 'tsig_algorithm', "tsig_key")
+        fields = (
+            "server",
+            "server_port",
+            "tsig_key_name",
+            "tsig_algorithm",
+            "tsig_key",
+            "protocol",
+        )
 
 
 class ZoneSerializer(NetBoxModelSerializer):
     class Meta:
         model = Zone
-        fields = ('name', 'ttl', 'server', 'protocol')
+        fields = ("name", "ttl", "server")
 
 
 class ReverseZoneSerializer(NetBoxModelSerializer):


### PR DESCRIPTION
The protocol field (TCP/UDP) belongs to the Server model but was incorrectly declared in ZoneSerializer instead of ServerSerializer. 
This causes a django.core.exceptions.ImproperlyConfigured error on any operation involving the Zone serializer, including editing a zone through the UI.
Fix
- Removed protocol from ZoneSerializer.fields (the Zone model does not have this field)
- Added protocol to ServerSerializer.fields (where it actually belongs)

