### PR TITLE
Add Zone and Server API viewsets and fix ExtraDNSName endpoint

### DIFF
--- a/netbox_ddns/api/serializers.py
+++ b/netbox_ddns/api/serializers.py
@@ -7,20 +7,21 @@ from ..models import ExtraDNSName, Server, Zone, ReverseZone
 
 class ExtraDNSNameSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_ddns-api:extradnsname-detail'
+        view_name="plugins-api:netbox_ddns-api:extradnsname-detail"
     )
     ip_address = PrimaryKeyRelatedField(queryset=IPAddress.objects.all())
 
     class Meta:
         model = ExtraDNSName
-        fields = ('id', 'ip_address', 'name', 'url')
-        read_only_fields = ('id', 'url')
+        fields = ("id", "ip_address", "name", "url")
+        read_only_fields = ("id", "url")
 
 
 class ServerSerializer(NetBoxModelSerializer):
     class Meta:
         model = Server
         fields = (
+            "id",
             "server",
             "server_port",
             "tsig_key_name",
@@ -28,15 +29,18 @@ class ServerSerializer(NetBoxModelSerializer):
             "tsig_key",
             "protocol",
         )
+        extra_kwargs = {
+            "tsig_key": {"write_only": True},
+        }
 
 
 class ZoneSerializer(NetBoxModelSerializer):
     class Meta:
         model = Zone
-        fields = ("name", "ttl", "server")
+        fields = ("id", "name", "ttl", "server")
 
 
 class ReverseZoneSerializer(NetBoxModelSerializer):
     class Meta:
         model = ReverseZone
-        fields = ('name', 'prefix', 'ttl', 'server')
+        fields = ("name", "prefix", "ttl", "server")

--- a/netbox_ddns/api/urls.py
+++ b/netbox_ddns/api/urls.py
@@ -2,9 +2,11 @@ from netbox.api.routers import NetBoxRouter
 from . import views
 
 
-app_name = 'netbox_ddns'
+app_name = "netbox_ddns"
 
 router = NetBoxRouter()
-router.register('extra-dns-name', views.ExtraDNSNameViewSet)
+router.register("extra-dns-name", views.ExtraDNSNameViewSet)
+router.register("zone", views.ZoneViewSet)
+router.register("server", views.ServerViewSet)
 
 urlpatterns = router.urls

--- a/netbox_ddns/api/views.py
+++ b/netbox_ddns/api/views.py
@@ -5,7 +5,6 @@ from .serializers import ExtraDNSNameSerializer
 
 
 class ExtraDNSNameViewSet(NetBoxModelViewSet):
-    queryset = ExtraDNSName.objects.all()
+    queryset = ExtraDNSName.objects.select_related("ip_address").all()
     serializer_class = ExtraDNSNameSerializer
     filterset_class = ExtraDNSNameFilterSet
-

--- a/netbox_ddns/api/views.py
+++ b/netbox_ddns/api/views.py
@@ -1,10 +1,22 @@
 from netbox.api.viewsets import NetBoxModelViewSet
-from ..filtersets import ExtraDNSNameFilterSet
-from ..models import ExtraDNSName
-from .serializers import ExtraDNSNameSerializer
+from ..filtersets import ExtraDNSNameFilterSet, ServerFilterSet, ZoneFilterSet
+from ..models import ExtraDNSName, Server, Zone
+from .serializers import ExtraDNSNameSerializer, ServerSerializer, ZoneSerializer
 
 
 class ExtraDNSNameViewSet(NetBoxModelViewSet):
     queryset = ExtraDNSName.objects.select_related("ip_address").all()
     serializer_class = ExtraDNSNameSerializer
     filterset_class = ExtraDNSNameFilterSet
+
+
+class ZoneViewSet(NetBoxModelViewSet):
+    queryset = Zone.objects.select_related("server").all()
+    serializer_class = ZoneSerializer
+    filterset_class = ZoneFilterSet
+
+
+class ServerViewSet(NetBoxModelViewSet):
+    queryset = Server.objects.all()
+    serializer_class = ServerSerializer
+    filterset_class = ServerFilterSet

--- a/netbox_ddns/models.py
+++ b/netbox_ddns/models.py
@@ -409,6 +409,7 @@ class ExtraDNSName(NetBoxModel):
     before_save = None
 
     class Meta:
+        ordering = ('name',)
         unique_together = (
             ('ip_address', 'name'),
         )


### PR DESCRIPTION
- Fix N+1 query on ExtraDNSName API endpoint by adding select_related('ip_address')
- Add ZoneViewSet and ServerViewSet API endpoints with select_related optimization
